### PR TITLE
fix: 심층분석 API 프록시 ECONNREFUSED 오류 수정

### DIFF
--- a/mud-frontend/src/app/api/trends/[id]/deep-analysis/route.ts
+++ b/mud-frontend/src/app/api/trends/[id]/deep-analysis/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { id } = params;
+
+  const res = await fetch(`${API_BASE}/api/trends/${id}/deep-analysis`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: `Backend error: ${res.status}` },
+      { status: res.status }
+    );
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}


### PR DESCRIPTION
## Summary
- 온디맨드 심층분석 기능에서 500 에러(ECONNREFUSED) 발생하는 문제 수정
- **원인**: next.config.mjs의 rewrites()가 빌드 타임에 NEXT_PUBLIC_API_URL을 평가하여 localhost:8080이 고정됨
- **해결**: Next.js API Route 추가하여 런타임에 환경변수를 읽어 백엔드로 프록시

## Test plan
- [ ] 배포 후 심층분석 버튼 클릭 시 정상 응답 확인
- [ ] 기존 API 엔드포인트 정상 동작 확인