### PR TITLE
fix: GlobalExceptionHandler 에러 로깅 누락 수정

### DIFF
--- a/mud-backend/src/main/java/com/mud/api/controller/GlobalExceptionHandler.java
+++ b/mud-backend/src/main/java/com/mud/api/controller/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.mud.api.controller;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -21,6 +23,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleGeneric(Exception ex) {
+        log.error("Unhandled exception", ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
             "error", "Internal server error",
             "timestamp", LocalDateTime.now().toString()


### PR DESCRIPTION
## Summary
- GlobalExceptionHandler가 모든 예외를 삼키고 로그 없이 500만 반환하던 문제 수정
- log.error 추가로 실제 예외 메시지와 스택트레이스가 백엔드 로그에 출력되도록 변경

## Test plan
- [ ] 배포 후 심층분석 요청 시 백엔드 로그에 실제 에러 스택트레이스 확인