### PR TITLE
fix: 심층분석 LazyInitializationException 수정

### DIFF
--- a/mud-backend/src/main/java/com/mud/service/AnalysisService.java
+++ b/mud-backend/src/main/java/com/mud/service/AnalysisService.java
@@ -274,6 +274,9 @@ public class AnalysisService {
             return item.getDeepAnalysis();
         }
 
+        // 비동기 스레드에서 Hibernate 세션이 없으므로 lazy 컬렉션을 미리 초기화
+        item.getKeywords().size();
+
         CompletableFuture<String> future = inFlightDeepAnalysis.computeIfAbsent(trendItemId, id -> {
             CompletableFuture<String> f = CompletableFuture.supplyAsync(() -> {
                 try {


### PR DESCRIPTION
## Summary
- 심층분석 시 비동기 스레드에서 keywords lazy 컬렉션 접근 시 Hibernate 세션 부재로 LazyInitializationException 발생하던 문제 수정
- 비동기 실행 전 컬렉션을 미리 초기화하여 해결

## Test plan
- [ ] 심층분석 버튼 클릭 시 정상 분석 결과 반환 확인
- [ ] 백엔드 로그에 LazyInitializationException 미발생 확인