### PR TITLE
fix: 심층분석 LazyInitializationException 수정 (TransactionTemplate)

### DIFF
--- a/mud-backend/src/main/java/com/mud/service/AnalysisService.java
+++ b/mud-backend/src/main/java/com/mud/service/AnalysisService.java
@@ -267,15 +267,19 @@ public class AnalysisService {
     ) {}
 
     public String generateDeepAnalysis(Long trendItemId) {
-        TrendItem item = trendItemRepository.findById(trendItemId)
-            .orElseThrow(() -> new IllegalArgumentException("Trend item not found: " + trendItemId));
+        TransactionTemplate txRead = new TransactionTemplate(transactionManager);
+        txRead.setReadOnly(true);
+        TrendItem item = txRead.execute(status -> {
+            TrendItem i = trendItemRepository.findById(trendItemId)
+                .orElseThrow(() -> new IllegalArgumentException("Trend item not found: " + trendItemId));
+            // 비동기 스레드에서 Hibernate 세션이 없으므로 lazy 컬렉션을 미리 초기화
+            i.getKeywords().size();
+            return i;
+        });
 
         if (item.getDeepAnalysis() != null) {
             return item.getDeepAnalysis();
         }
-
-        // 비동기 스레드에서 Hibernate 세션이 없으므로 lazy 컬렉션을 미리 초기화
-        item.getKeywords().size();
 
         CompletableFuture<String> future = inFlightDeepAnalysis.computeIfAbsent(trendItemId, id -> {
             CompletableFuture<String> f = CompletableFuture.supplyAsync(() -> {


### PR DESCRIPTION
## Summary
- 심층분석 `generateDeepAnalysis`에서 `findById` 후 엔티티가 detached 상태가 되어 `keywords` lazy 컬렉션 접근 시 `LazyInitializationException` 발생하는 문제 수정
- `TransactionTemplate`으로 엔티티 로드와 컬렉션 초기화를 하나의 트랜잭션 안에서 수행하도록 변경

## Test plan
- [ ] 심층분석 버튼 클릭 시 정상 분석 결과 반환 확인
- [ ] 백엔드 로그에 LazyInitializationException 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
