### PR TITLE
fix: 심층분석 Claude API 타임아웃 240초로 증가

### DIFF
--- a/mud-backend/src/main/java/com/mud/service/AnalysisService.java
+++ b/mud-backend/src/main/java/com/mud/service/AnalysisService.java
@@ -311,7 +311,7 @@ public class AnalysisService {
             .bodyValue(requestBody)
             .retrieve()
             .bodyToMono(Map.class)
-            .timeout(Duration.ofSeconds(120))
+            .timeout(Duration.ofSeconds(240))
             .block();
 
         if (response == null) throw new RuntimeException("Claude API returned null for deep analysis");


### PR DESCRIPTION
## Summary
- 심층분석 Claude API 호출 타임아웃을 120초 → 240초로 증가
- 긴 프롬프트 + max_tokens 4096 설정으로 응답 생성에 120초 이상 소요되어 TimeoutException 발생하던 문제 해결

## Test plan
- [ ] 심층분석 버튼 클릭 후 240초 이내 정상 응답 확인
- [ ] 타임아웃 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
