### PR TITLE
[B3] 프로덕션 DB 기본 패스워드 제거

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
     environment:
       POSTGRES_DB: muddb
       POSTGRES_USER: mud
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-mudpassword}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD 환경변수를 설정해주세요}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/mud-backend/src/main/resources/application.yml
+++ b/mud-backend/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/muddb}
     username: ${SPRING_DATASOURCE_USERNAME:mud}
-    password: ${SPRING_DATASOURCE_PASSWORD:mudpassword}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
     hikari:
       maximum-pool-size: 15
       minimum-idle: 2


### PR DESCRIPTION
## Summary
- `docker-compose.prod.yml`: `${DB_PASSWORD:-mudpassword}` → `${DB_PASSWORD:?...}` — 환경변수 미설정 시 컨테이너 시작 실패
- `application.yml`: `${SPRING_DATASOURCE_PASSWORD:mudpassword}` → `${SPRING_DATASOURCE_PASSWORD:}` — 기본 패스워드 제거

## ⚠️ 배포 전 확인사항
- 프로덕션 환경(Railway 등)에 `DB_PASSWORD` 환경변수가 설정되어 있는지 반드시 확인

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)