### PR TITLE
[F4] fix: deploy-frontend 잡의 ci 의존성을 deploy-backend로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
 
   deploy-frontend:
     name: Deploy Frontend
-    needs: ci
+    needs: deploy-backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `deploy-frontend` 잡이 존재하지 않는 `ci` 잡을 `needs`로 참조하여 프론트엔드 배포가 실행되지 않던 문제 수정
- `needs: ci` → `needs: deploy-backend`로 변경하여 백엔드 배포 완료 후 프론트엔드 배포가 트리거되도록 수정

## Test plan
- [ ] main 브랜치에 push 시 deploy-backend → deploy-frontend 순서로 배포가 정상 실행되는지 확인
- [ ] GitHub Actions 워크플로 실행 로그에서 의존성 오류 없는지 확인

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)