### PR TITLE
[B2] 분석 파이프라인 동시성 버그 수정 (Redis 분산 락)

### DIFF
--- a/mud-backend/build.gradle
+++ b/mud-backend/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // Distributed Lock
+    implementation 'org.springframework.integration:spring-integration-redis'
+
     // Data
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/mud-backend/src/main/java/com/mud/config/RedisLockConfig.java
+++ b/mud-backend/src/main/java/com/mud/config/RedisLockConfig.java
@@ -1,0 +1,15 @@
+package com.mud.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.integration.redis.util.RedisLockRegistry;
+
+@Configuration
+public class RedisLockConfig {
+
+    @Bean
+    public RedisLockRegistry redisLockRegistry(RedisConnectionFactory connectionFactory) {
+        return new RedisLockRegistry(connectionFactory, "mud-lock", 600_000L);
+    }
+}

--- a/mud-backend/src/main/java/com/mud/service/AnalysisService.java
+++ b/mud-backend/src/main/java/com/mud/service/AnalysisService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import org.springframework.integration.redis.util.RedisLockRegistry;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
 
 @Service
 @Slf4j
@@ -39,6 +42,7 @@ public class AnalysisService {
     private final ObjectMapper objectMapper;
     private final PlatformTransactionManager transactionManager;
     private final CacheManager cacheManager;
+    private final RedisLockRegistry redisLockRegistry;
 
     @Value("${claude.api.model}")
     private String claudeModel;
@@ -70,29 +74,40 @@ public class AnalysisService {
 
     @Async
     public void analyzePendingItems() {
-        List<TrendItem> pendingItems = trendItemRepository
-            .findByAnalysisStatusInOrderByCrawledAtAsc(
-                List.of(TrendItem.AnalysisStatus.PENDING, TrendItem.AnalysisStatus.FAILED));
+        Lock lock = redisLockRegistry.obtain("analysis:pending");
 
-        if (pendingItems.isEmpty()) {
-            log.debug("No pending or failed items to analyze");
+        if (!lock.tryLock()) {
+            log.info("분석이 이미 진행 중입니다 (락 보유 중), 스킵합니다");
             return;
         }
 
-        List<List<TrendItem>> batches = partition(pendingItems, batchSize);
-        log.info("Starting batch analysis: {} items in {} batches (batchSize={}, concurrency={})",
-            pendingItems.size(), batches.size(), batchSize, concurrency);
+        try {
+            List<TrendItem> pendingItems = trendItemRepository
+                .findByAnalysisStatusInOrderByCrawledAtAsc(
+                    List.of(TrendItem.AnalysisStatus.PENDING, TrendItem.AnalysisStatus.FAILED));
 
-        AtomicInteger analyzedBatches = new AtomicInteger();
+            if (pendingItems.isEmpty()) {
+                log.debug("No pending or failed items to analyze");
+                return;
+            }
 
-        List<CompletableFuture<Void>> futures = batches.stream()
-            .map(batch -> CompletableFuture.runAsync(
-                () -> analyzeBatch(batch, analyzedBatches, batches.size()), executor))
-            .toList();
+            List<List<TrendItem>> batches = partition(pendingItems, batchSize);
+            log.info("Starting batch analysis: {} items in {} batches (batchSize={}, concurrency={})",
+                pendingItems.size(), batches.size(), batchSize, concurrency);
 
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+            AtomicInteger analyzedBatches = new AtomicInteger();
 
-        log.info("Analysis complete: {}/{} batches processed", analyzedBatches.get(), batches.size());
+            List<CompletableFuture<Void>> futures = batches.stream()
+                .map(batch -> CompletableFuture.runAsync(
+                    () -> analyzeBatch(batch, analyzedBatches, batches.size()), executor))
+                .toList();
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+            log.info("Analysis complete: {}/{} batches processed", analyzedBatches.get(), batches.size());
+        } finally {
+            lock.unlock();
+        }
     }
 
     private void analyzeBatch(List<TrendItem> batch, AtomicInteger analyzedBatches, int totalBatches) {


### PR DESCRIPTION
## Summary
- `analyzePendingItems()`에 Redis 분산 락 적용하여 동시 호출 시 중복 분석 방지
- `spring-integration-redis`의 `RedisLockRegistry` 사용 (기존 Redis 인프라 재사용)
- 락 획득 실패 시 즉시 스킵 (비차단)

## 변경 파일
- `build.gradle` — `spring-integration-redis` 의존성 추가
- `RedisLockConfig.java` — `RedisLockRegistry` 빈 등록 (TTL 10분)
- `AnalysisService.java` — `analyzePendingItems()`에 `tryLock()`/`unlock()` 적용

## 동작 방식
- StartupCrawlRunner, Quartz, AdminController 중 먼저 호출한 쪽이 락 획득
- 나머지 호출은 "분석이 이미 진행 중입니다" 로그 후 스킵
- 락 TTL 10분 (JVM 크래시 시 안전장치)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)