### PR TITLE
[F1] feat: URL 스킴 검증으로 XSS 방지

### DIFF
--- a/mud-frontend/src/app/trends/[id]/page.tsx
+++ b/mud-frontend/src/app/trends/[id]/page.tsx
@@ -3,6 +3,7 @@ import { api } from '@/lib/api';
 import { notFound } from 'next/navigation';
 import { BookmarkButton } from '@/components/ui/BookmarkButton';
 import { DeepAnalysisSection } from '@/components/ui/DeepAnalysisSection';
+import { sanitizeUrl } from '@/lib/url';
 
 const SOURCE_CONFIG: Record<string, { label: string; color: string; emoji: string }> = {
   GITHUB: { label: 'GitHub', color: '#e2e8f0', emoji: '🐙' },
@@ -125,7 +126,7 @@ export default async function TrendDetailPage({ params }: Props) {
 
       <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
         <a
-          href={item.originalUrl}
+          href={sanitizeUrl(item.originalUrl)}
           target="_blank"
           rel="noopener noreferrer"
           className="page-btn"

--- a/mud-frontend/src/components/trend/TrendCard.tsx
+++ b/mud-frontend/src/components/trend/TrendCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import type { TrendItem } from '@/lib/types';
 import { BookmarkButton } from '@/components/ui/BookmarkButton';
+import { sanitizeUrl } from '@/lib/url';
 
 const SOURCE_CONFIG: Record<string, { label: string; color: string; emoji: string }> = {
   GITHUB: { label: 'GitHub', color: '#e2e8f0', emoji: '🐙' },
@@ -77,7 +78,7 @@ export function TrendCard({ item }: Props) {
       </div>
 
       <h3 className="trend-card-title">
-        <a href={item.originalUrl} target="_blank" rel="noopener noreferrer">
+        <a href={sanitizeUrl(item.originalUrl)} target="_blank" rel="noopener noreferrer">
           {item.title}
         </a>
       </h3>

--- a/mud-frontend/src/lib/url.ts
+++ b/mud-frontend/src/lib/url.ts
@@ -1,0 +1,11 @@
+export function sanitizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return url;
+    }
+  } catch {
+    // invalid URL
+  }
+  return '#';
+}


### PR DESCRIPTION
## Summary
- `sanitizeUrl` 유틸 추가 — `http://`, `https://`만 허용, 그 외 스킴은 `#`으로 대체
- `TrendCard.tsx`와 `trends/[id]/page.tsx`의 원문 링크에 적용

## Test plan
- [ ] `javascript:alert(1)` 같은 URL이 `#`으로 치환되는지 확인
- [ ] 정상 URL(`https://...`)은 그대로 동작하는지 확인
- [ ] lint + build 통과 확인 완료

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)