### PR TITLE
[B6] 키워드 검색 성능 개선 — pg_trgm GIN 인덱스

### DIFF
--- a/mud-backend/src/main/resources/db/migration/V4__add_trgm_gin_indexes.sql
+++ b/mud-backend/src/main/resources/db/migration/V4__add_trgm_gin_indexes.sql
@@ -1,0 +1,6 @@
+-- pg_trgm 확장 활성화 (LIKE '%keyword%' 검색에 GIN 인덱스 사용 가능)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- title, korean_summary에 GIN 인덱스 추가
+CREATE INDEX idx_trend_title_trgm ON trend_items USING gin (title gin_trgm_ops);
+CREATE INDEX idx_trend_summary_trgm ON trend_items USING gin (korean_summary gin_trgm_ops);


### PR DESCRIPTION
## Summary
- PostgreSQL `pg_trgm` 확장 활성화
- `trend_items.title`, `korean_summary`에 GIN 인덱스 추가
- 기존 `LIKE '%keyword%'` 쿼리가 풀 테이블 스캔 → 인덱스 스캔으로 개선
- 쿼리 코드 변경 없이 Flyway 마이그레이션만 추가

## 변경 파일
- `V4__add_trgm_gin_indexes.sql` — 신규 Flyway 마이그레이션

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)