### PR TITLE
[B11] 하드웨어/반도체 카테고리 추가

### DIFF
--- a/mud-backend/src/main/java/com/mud/service/AnalysisService.java
+++ b/mud-backend/src/main/java/com/mud/service/AnalysisService.java
@@ -212,7 +212,7 @@ public class AnalysisService {
             [
               {
                 "koreanSummary": "현업 개발자 관점에서 2-3문장으로 핵심을 요약 (한국어로 작성)",
-                "categorySlug": "ai-ml 또는 rag 또는 llm 또는 cpp 또는 java 또는 devops 또는 webdev 또는 security 또는 general 중 하나",
+                "categorySlug": "ai-ml 또는 rag 또는 llm 또는 cpp 또는 java 또는 devops 또는 webdev 또는 security 또는 hardware 또는 general 중 하나",
                 "relevanceScore": 1부터 5 사이의 정수,
                 "keywords": ["키워드1", "키워드2", "키워드3"]
               }

--- a/mud-backend/src/main/resources/db/migration/V5__add_hardware_category.sql
+++ b/mud-backend/src/main/resources/db/migration/V5__add_hardware_category.sql
@@ -1,0 +1,2 @@
+INSERT INTO categories (slug, display_name, emoji, sort_order) VALUES
+    ('hardware', '하드웨어 / 반도체', '🔩', 10);


### PR DESCRIPTION
## Summary
- Flyway V5 마이그레이션으로 `hardware` (하드웨어 / 반도체) 카테고리 추가
- AnalysisService Claude 프롬프트에 `hardware` slug 반영

## 변경 파일
- `V5__add_hardware_category.sql` — 신규 마이그레이션
- `AnalysisService.java` — categorySlug 선택지에 hardware 추가

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)