### PR TITLE
[OPS1] deploy.yml 중복 Railway 배포 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,12 @@
-name: Deploy to Railway
+name: Post-merge Ops Gate
 
 on:
   push:
     branches: [main]
 
-concurrency:
-  group: deploy-production
-  cancel-in-progress: true
-
 jobs:
-  # Ops 승인 없이 머지된 직접 push 방지 (branch protection 우회 대비)
+  # Ops 승인 없이 머지된 직접 push 감지 (branch protection 우회 대비)
+  # Railway 배포는 Railway 자체 자동 배포로 처리 (main push 감지)
   verify-ops-gate:
     name: Verify Ops Approval
     runs-on: ubuntu-latest
@@ -40,39 +37,9 @@ jobs:
             -q '[.[] | select(.context == "ops-gate/approval")] | .[0].state' 2>/dev/null || echo "")
 
           if [ "$OPS_STATUS" = "success" ]; then
-            echo "✅ Ops 승인 확인됨. 배포 진행."
+            echo "✅ Ops 승인 확인됨."
           else
-            echo "🚫 Ops 승인이 없는 PR이 머지되었습니다. 배포를 차단합니다."
+            echo "🚫 Ops 승인이 없는 PR이 머지되었습니다."
             echo "ops-gate status: $OPS_STATUS"
             exit 1
           fi
-
-  deploy-backend:
-    name: Deploy Backend
-    needs: verify-ops-gate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Railway CLI
-        run: npm i -g @railway/cli
-
-      - name: Deploy Backend
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway up --service mud-backend
-
-  deploy-frontend:
-    name: Deploy Frontend
-    needs: deploy-backend
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Railway CLI
-        run: npm i -g @railway/cli
-
-      - name: Deploy Frontend
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway up --service mud-frontend


### PR DESCRIPTION
## Summary
- Railway 자체 자동 배포가 main push를 감지하여 배포하므로 GitHub Actions의 `railway up` 명령 제거
- `verify-ops-gate` job만 유지 (Ops 승인 없이 머지된 커밋 감지용)
- `deploy-backend`, `deploy-frontend` job 삭제
- concurrency 설정 제거 (배포 job이 없으므로 불필요)

## 원인
`RAILWAY_TOKEN` 만료 또는 Railway CLI 설정 문제로 PR #63, #65, #66 머지 후 배포 워크플로우가 매번 실패. Railway 자체 배포는 정상 동작 중.

## Test plan
- [ ] main 머지 후 Post-merge Ops Gate 워크플로우가 정상 실행되는지 확인
- [ ] Railway 자체 배포가 여전히 정상 동작하는지 확인

Closes #74