### PR TITLE
[Hotfix] API 호출 로깅 추가 — 주간 다이제스트 디버깅

### DIFF
--- a/mud-frontend/src/app/digest/page.tsx
+++ b/mud-frontend/src/app/digest/page.tsx
@@ -9,7 +9,10 @@ export const metadata: Metadata = {
 };
 
 export default async function DigestPage() {
-  const report = await api.getWeeklyReport().catch(() => null);
+  const report = await api.getWeeklyReport().catch((e) => {
+    console.error('[digest] getWeeklyReport failed:', e);
+    return null;
+  });
 
   if (!report) {
     return (

--- a/mud-frontend/src/lib/api.ts
+++ b/mud-frontend/src/lib/api.ts
@@ -16,11 +16,14 @@ async function apiFetch<T>(
     });
   }
 
+  console.log(`[api] ${path} → ${url.toString()}`);
+
   const res = await fetch(url.toString(), {
     next: { revalidate },
   });
 
   if (!res.ok) {
+    console.error(`[api] ${path} failed: ${res.status} ${res.statusText}`);
     throw new Error(`API error ${res.status}: ${path}`);
   }
 


### PR DESCRIPTION
## Summary
- `apiFetch`에 요청 URL 로깅 추가 (`[api] /api/reports/weekly → https://...`)
- 실패 시 상태코드 + statusText 로깅
- digest 페이지 catch에 에러 상세 로깅

배포 후 Railway 로그에서 다음을 확인:
1. `[api] /api/reports/weekly → ???` — 어떤 URL로 요청하는지
2. `[api] /api/reports/weekly failed: ???` — 실패 원인 (404/500/connection refused)
3. `[digest] getWeeklyReport failed: ???` — 에러 상세

## Test plan
- [ ] 배포 후 Railway 로그에서 API 호출 로그 확인
- [ ] 주간 다이제스트 페이지 접근 시 로그 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)