### PR TITLE
[F15] fix: 카드 accent 색상 인디고 단색 통일

### DIFF
--- a/mud-frontend/src/app/globals.css
+++ b/mud-frontend/src/app/globals.css
@@ -139,7 +139,7 @@ a:hover { color: var(--color-accent-hover); }
 .trend-card {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-top: 3px solid var(--card-accent, var(--color-border));
+  border-top: 3px solid var(--color-accent);
   border-radius: 8px;
   padding: 16px;
   display: flex;

--- a/mud-frontend/src/components/trend/TrendCard.tsx
+++ b/mud-frontend/src/components/trend/TrendCard.tsx
@@ -24,7 +24,6 @@ export function TrendCard({ item }: Props) {
   return (
     <article
       className={`trend-card ${isRead(item.id) ? 'trend-card-read' : ''}`}
-      style={{ '--card-accent': sourceConf.color } as React.CSSProperties}
     >
       <div className="trend-card-header">
         <span


### PR DESCRIPTION
## Summary
- 카드 상단 `border-top` 색상을 소스별 31가지 → 브랜드 인디고(`#6366f1`) 단색으로 통일
- TrendCard에서 `--card-accent` CSS 변수 제거
- PM 결정(#52 코멘트) 반영

## Test plan
- [ ] 모든 카드의 상단 accent가 인디고 색상으로 통일되는지 확인
- [ ] 소스 배지 색상은 기존과 동일한지 확인
- [ ] lint + build 통과 확인 완료

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)