### PR TITLE
[B21] minScore 필터 score_total 기반으로 전환

### DIFF
--- a/mud-backend/src/main/java/com/mud/api/controller/TrendController.java
+++ b/mud-backend/src/main/java/com/mud/api/controller/TrendController.java
@@ -37,7 +37,7 @@ public class TrendController {
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String source,
-            @RequestParam(defaultValue = "1") int minScore,
+            @RequestParam(defaultValue = "0") int minScore,
             @RequestParam(required = false) String keyword) {
 
         TrendFilterRequest filter = TrendFilterRequest.builder()

--- a/mud-backend/src/main/java/com/mud/domain/repository/TrendItemRepository.java
+++ b/mud-backend/src/main/java/com/mud/domain/repository/TrendItemRepository.java
@@ -23,13 +23,16 @@ public interface TrendItemRepository extends JpaRepository<TrendItem, Long> {
         WHERE t.analysisStatus = 'DONE'
         AND (:categorySlug IS NULL OR c.slug = :categorySlug)
         AND (:source IS NULL OR CAST(t.source AS string) = :source)
-        AND t.relevanceScore >= :minScore
+        AND (
+            (t.scoreTotal IS NOT NULL AND t.scoreTotal >= :minScore)
+            OR (t.scoreTotal IS NULL AND t.relevanceScore >= :minScore / 20)
+        )
         AND (
             CAST(:keyword AS string) IS NULL
             OR LOWER(t.title) LIKE LOWER(CONCAT('%', CAST(:keyword AS string), '%'))
             OR LOWER(t.koreanSummary) LIKE LOWER(CONCAT('%', CAST(:keyword AS string), '%'))
         )
-        ORDER BY t.publishedAt DESC NULLS LAST, t.relevanceScore DESC
+        ORDER BY t.publishedAt DESC NULLS LAST, t.scoreTotal DESC NULLS LAST
         """)
     Page<TrendItem> findWithFilters(
         @Param("categorySlug") String categorySlug,

--- a/mud-backend/src/main/java/com/mud/dto/request/TrendFilterRequest.java
+++ b/mud-backend/src/main/java/com/mud/dto/request/TrendFilterRequest.java
@@ -17,7 +17,7 @@ public class TrendFilterRequest {
     private String source;
 
     @Builder.Default
-    private int minScore = 1;
+    private int minScore = 0;
 
     private String keyword;
 

--- a/mud-backend/src/test/java/com/mud/service/TrendServiceTest.java
+++ b/mud-backend/src/test/java/com/mud/service/TrendServiceTest.java
@@ -57,7 +57,7 @@ class TrendServiceTest {
             PageRequest.of(0, 20), 1
         );
 
-        when(trendItemRepository.findWithFilters(isNull(), isNull(), eq(1), isNull(), any()))
+        when(trendItemRepository.findWithFilters(isNull(), isNull(), eq(0), isNull(), any()))
             .thenReturn(page);
 
         TrendPageResponse result = trendService.getTrends(filter);


### PR DESCRIPTION
## Summary
- `findWithFilters` JPQL을 `scoreTotal` 기반 필터링으로 전환
- `scoreTotal IS NULL`인 기존 데이터 호환 (relevanceScore / 20 fallback)
- 정렬 기준: `scoreTotal DESC NULLS LAST`
- minScore 기본값: 1 → 0 (100점 체계)

## 변경 파일
- `TrendItemRepository.java` — JPQL 수정
- `TrendController.java` — minScore 기본값 0
- `TrendFilterRequest.java` — 기본값 0
- `TrendServiceTest.java` — 테스트 기대값 수정

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
