### PR TITLE
[B27] BE 전체 scoreTotal 기반 전환

### DIFF
--- a/mud-backend/src/main/java/com/mud/api/controller/TrendController.java
+++ b/mud-backend/src/main/java/com/mud/api/controller/TrendController.java
@@ -37,7 +37,7 @@ public class TrendController {
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String source,
-            @RequestParam(defaultValue = "0") int minScore,
+            @RequestParam(defaultValue = "25") int minScore,
             @RequestParam(required = false) String keyword) {
 
         TrendFilterRequest filter = TrendFilterRequest.builder()

--- a/mud-backend/src/main/java/com/mud/domain/repository/TrendItemRepository.java
+++ b/mud-backend/src/main/java/com/mud/domain/repository/TrendItemRepository.java
@@ -66,7 +66,7 @@ public interface TrendItemRepository extends JpaRepository<TrendItem, Long> {
         LEFT JOIN FETCH t.category
         WHERE t.analysisStatus = :status
         AND t.crawledAt BETWEEN :start AND :end
-        ORDER BY t.relevanceScore DESC, t.publishedAt DESC
+        ORDER BY t.scoreTotal DESC NULLS LAST, t.publishedAt DESC
         """)
     List<TrendItem> findByStatusAndPeriodWithCategory(
         @Param("status") TrendItem.AnalysisStatus status,

--- a/mud-backend/src/main/java/com/mud/dto/request/TrendFilterRequest.java
+++ b/mud-backend/src/main/java/com/mud/dto/request/TrendFilterRequest.java
@@ -17,7 +17,7 @@ public class TrendFilterRequest {
     private String source;
 
     @Builder.Default
-    private int minScore = 0;
+    private int minScore = 25;
 
     private String keyword;
 

--- a/mud-backend/src/main/java/com/mud/service/WeeklyReportService.java
+++ b/mud-backend/src/main/java/com/mud/service/WeeklyReportService.java
@@ -67,7 +67,7 @@ public class WeeklyReportService {
         int totalCount = periodItems.size();
 
         List<TrendItem> highlights = periodItems.stream()
-            .filter(item -> item.getRelevanceScore() != null && item.getRelevanceScore() >= 4)
+            .filter(item -> item.getScoreTotal() != null && item.getScoreTotal() >= 65)
             .limit(15)
             .toList();
 
@@ -78,7 +78,8 @@ public class WeeklyReportService {
                 "id", item.getId(),
                 "title", item.getTitle(),
                 "source", item.getSource().name(),
-                "relevanceScore", item.getRelevanceScore(),
+                "scoreTotal", item.getScoreTotal() != null ? item.getScoreTotal() : 0,
+                "relevanceScore", item.getRelevanceScore() != null ? item.getRelevanceScore() : 0,
                 "categorySlug", item.getCategory() != null ? item.getCategory().getSlug() : "general",
                 "koreanSummary", item.getKoreanSummary() != null ? item.getKoreanSummary() : "",
                 "originalUrl", item.getOriginalUrl()
@@ -122,8 +123,8 @@ public class WeeklyReportService {
             .collect(Collectors.groupingBy(item -> item.getCategory().getSlug()))
             .forEach((slug, catItems) -> {
                 double avgScore = catItems.stream()
-                    .filter(i -> i.getRelevanceScore() != null)
-                    .mapToInt(TrendItem::getRelevanceScore)
+                    .filter(i -> i.getScoreTotal() != null)
+                    .mapToInt(i -> i.getScoreTotal().intValue())
                     .average().orElse(0);
                 stats.put(slug, Map.of("count", catItems.size(), "avgScore", Math.round(avgScore * 10) / 10.0));
             });

--- a/mud-backend/src/test/java/com/mud/service/TrendServiceTest.java
+++ b/mud-backend/src/test/java/com/mud/service/TrendServiceTest.java
@@ -57,7 +57,7 @@ class TrendServiceTest {
             PageRequest.of(0, 20), 1
         );
 
-        when(trendItemRepository.findWithFilters(isNull(), isNull(), eq(0), isNull(), any()))
+        when(trendItemRepository.findWithFilters(isNull(), isNull(), eq(25), isNull(), any()))
             .thenReturn(page);
 
         TrendPageResponse result = trendService.getTrends(filter);


### PR DESCRIPTION
## Summary
- BE 전체에서 `relevanceScore`(1~5) 의존을 `scoreTotal`(0~100)로 전환
- 주간 리포트, 하이라이트 선별, 카테고리 통계, 기본 필터값 모두 변경

## 변경 내용
| 대상 | 변경 전 | 변경 후 |
|------|---------|---------|
| 주간 리포트 정렬 | relevanceScore DESC | scoreTotal DESC NULLS LAST |
| 하이라이트 필터 | relevanceScore >= 4 | scoreTotal >= 65 |
| highlights JSON | relevanceScore | scoreTotal + relevanceScore |
| 카테고리 평균 | relevanceScore 기반 | scoreTotal 기반 |
| minScore 기본값 | 0 | 25 |

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
