### PR TITLE
[F33] feat: 주간 다이제스트 하이라이트 상세 정보 표시

### DIFF
--- a/mud-frontend/next-env.d.ts
+++ b/mud-frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/mud-frontend/src/app/digest/page.tsx
+++ b/mud-frontend/src/app/digest/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { api } from '@/lib/api';
+import { SOURCE_CONFIG } from '@/constants/sources';
 
 export const metadata: Metadata = {
   title: '주간 다이제스트',
@@ -126,12 +127,7 @@ export default async function DigestPage() {
                   padding: '12px',
                 }}
               >
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
-                  {(item.scoreTotal != null || item.relevanceScore != null) && (
-                    <span style={{ color: '#a855f7', fontWeight: 600, fontSize: '12px' }}>
-                      ★{String(item.scoreTotal ?? (Number(item.relevanceScore) * 20))}
-                    </span>
-                  )}
+                <div style={{ marginBottom: '6px' }}>
                   {item.id != null ? (
                     <Link href={`/trends/${String(item.id)}`} style={{ fontSize: '14px', fontWeight: 600 }}>
                       {String(item.title ?? '')}
@@ -140,8 +136,28 @@ export default async function DigestPage() {
                     <span style={{ fontSize: '14px', fontWeight: 600 }}>{String(item.title ?? '')}</span>
                   )}
                 </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px', flexWrap: 'wrap' }}>
+                  {(item.scoreTotal != null || item.relevanceScore != null) && (
+                    <span style={{ color: '#a855f7', fontWeight: 600, fontSize: '12px' }}>
+                      ★{String(item.scoreTotal ?? (Number(item.relevanceScore) * 20))}
+                    </span>
+                  )}
+                  {item.source != null && (() => {
+                    const src = SOURCE_CONFIG[String(item.source)];
+                    return src ? (
+                      <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>
+                        {src.emoji} {src.label}
+                      </span>
+                    ) : null;
+                  })()}
+                  {item.categorySlug != null && (
+                    <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>
+                      {String(item.categorySlug)}
+                    </span>
+                  )}
+                </div>
                 {item.koreanSummary != null && (
-                  <p style={{ fontSize: '13px', color: 'var(--color-text-muted)', lineHeight: 1.6 }}>
+                  <p style={{ fontSize: '13px', color: 'var(--color-text-muted)', lineHeight: 1.6, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
                     {String(item.koreanSummary)}
                   </p>
                 )}


### PR DESCRIPTION
## Summary
- 제목을 상단에 크게 배치
- 점수(100점) + 소스(이모지+라벨) + 카테고리 slug 메타 라인 추가
- 한국어 요약 2줄 말줄임 표시
- SOURCE_CONFIG import하여 소스 이모지/라벨 매핑

## Test plan
- [ ] `/digest` 하이라이트에 소스 이모지+라벨이 표시되는지 확인
- [ ] 카테고리 slug가 표시되는지 확인
- [ ] 한국어 요약이 2줄까지만 보이고 말줄임되는지 확인
- [ ] 점수가 100점 기준으로 표시되는지 확인
- [ ] lint + build 통과 확인 완료

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)