### PR TITLE
[F36] feat: CSP unsafe-inline 제거 — nonce 기반 전환

### DIFF
--- a/mud-frontend/next.config.mjs
+++ b/mud-frontend/next.config.mjs
@@ -26,20 +26,7 @@ const nextConfig = {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
           },
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-              "img-src 'self' data: https:",
-              "font-src 'self' data: https://fonts.gstatic.com",
-              "connect-src 'self' " + (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080'),
-              "frame-ancestors 'none'",
-              "base-uri 'self'",
-              "form-action 'self'",
-            ].join('; '),
-          },
+          // CSP is set dynamically in middleware.ts with nonce
         ],
       },
     ];

--- a/mud-frontend/src/app/globals.css
+++ b/mud-frontend/src/app/globals.css
@@ -1,5 +1,5 @@
 /* Korean font stack + base styles */
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap');
+/* Google Fonts loaded via <link> in layout.tsx for CSP nonce compatibility */
 
 *, *::before, *::after {
   box-sizing: border-box;

--- a/mud-frontend/src/app/layout.tsx
+++ b/mud-frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import './globals.css';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { MobileNav } from '@/components/layout/MobileNav';
@@ -34,11 +35,20 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const headersList = await headers();
+  const nonce = headersList.get('x-nonce') ?? '';
   const categories = await api.getCategories().catch(() => []);
 
   return (
     <html lang="ko">
-      <body>
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap"
+          nonce={nonce}
+        />
+      </head>
+      <body nonce={nonce}>
         <div className="app-layout">
           <div className="sidebar-desktop">
             <Sidebar categories={categories} />

--- a/mud-frontend/src/middleware.ts
+++ b/mud-frontend/src/middleware.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
+
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com`,
+    "img-src 'self' data: https:",
+    "font-src 'self' data: https://fonts.gstatic.com",
+    `connect-src 'self' ${apiUrl}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ');
+
+  const response = NextResponse.next({
+    request: {
+      headers: new Headers({
+        ...Object.fromEntries(request.headers),
+        'x-nonce': nonce,
+      }),
+    },
+  });
+
+  response.headers.set('Content-Security-Policy', csp);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    { source: '/((?!api|_next/static|_next/image|favicon.svg).*)' },
+  ],
+};


### PR DESCRIPTION
## Summary
- **middleware.ts 신규**: 매 요청마다 `crypto.randomUUID()` 기반 nonce 생성
- **CSP 강화**: `unsafe-inline` + `unsafe-eval` 제거 → `nonce-{랜덤}` 전환
- **next.config.mjs**: CSP 헤더를 middleware로 이전 (다른 보안 헤더는 유지)
- **Google Fonts**: CSS `@import` → layout.tsx `<link nonce>` 전환
- **nonce 전달**: `x-nonce` 헤더 → `headers()` → layout.tsx → `<body nonce>`

## 변경 전/후

```
Before: script-src 'self' 'unsafe-inline' 'unsafe-eval'
After:  script-src 'self' 'nonce-abc123...'
```

## Test plan
- [ ] 프로덕션 배포 후 페이지가 정상 렌더링되는지 확인
- [ ] DevTools Console에 CSP 관련 에러가 없는지 확인
- [ ] 응답 헤더에 Content-Security-Policy가 nonce 포함으로 설정되는지 확인
- [ ] Google Fonts가 정상 로드되는지 확인
- [ ] 심층분석 마크다운 렌더링이 깨지지 않는지 확인
- [ ] lint + build + test 통과 확인 완료

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)