### PR TITLE
hotfix: rescore force 파라미터 — 강제 재채점

### DIFF
--- a/mud-backend/src/main/java/com/mud/api/controller/AdminController.java
+++ b/mud-backend/src/main/java/com/mud/api/controller/AdminController.java
@@ -58,9 +58,10 @@ public class AdminController {
     @PostMapping("/rescore")
     public ResponseEntity<Map<String, String>> triggerRescore(
             @RequestParam(required = false) @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE) java.time.LocalDate from,
-            @RequestParam(required = false) @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE) java.time.LocalDate to) {
-        log.info("재평가 배치 트리거: from={}, to={}", from, to);
-        analysisService.rescoreExistingItems(from, to);
+            @RequestParam(required = false) @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE) java.time.LocalDate to,
+            @RequestParam(defaultValue = "false") boolean force) {
+        log.info("재평가 배치 트리거: from={}, to={}, force={}", from, to, force);
+        analysisService.rescoreExistingItems(from, to, force);
         return ResponseEntity.ok(Map.of("status", "재평가 시작됨 - 백그라운드에서 실행 중"));
     }
 

--- a/mud-backend/src/main/java/com/mud/service/AnalysisService.java
+++ b/mud-backend/src/main/java/com/mud/service/AnalysisService.java
@@ -388,7 +388,7 @@ public class AnalysisService {
     private final java.util.concurrent.atomic.AtomicBoolean rescoreInProgress = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     @Async
-    public void rescoreExistingItems(java.time.LocalDate from, java.time.LocalDate to) {
+    public void rescoreExistingItems(java.time.LocalDate from, java.time.LocalDate to, boolean force) {
         Lock rescoreLock = redisLockRegistry.obtain("analysis:rescore");
         if (!rescoreLock.tryLock()) {
             log.info("재평가가 이미 진행 중입니다 (분산 락 보유 중)");
@@ -407,11 +407,22 @@ public class AnalysisService {
             TransactionTemplate txRead = new TransactionTemplate(transactionManager);
             txRead.setReadOnly(true);
             List<Long> doneItemIds = txRead.execute(status -> {
+                if (from != null && force) {
+                    LocalDateTime fromDt = from.atStartOfDay();
+                    LocalDateTime toDt = (to != null ? to : java.time.LocalDate.now()).plusDays(1).atStartOfDay();
+                    return trendItemRepository.findByStatusAndPeriodWithCategory(
+                        TrendItem.AnalysisStatus.DONE, fromDt, toDt)
+                        .stream().map(TrendItem::getId).toList();
+                }
                 if (from != null) {
                     LocalDateTime fromDt = from.atStartOfDay();
                     LocalDateTime toDt = (to != null ? to : java.time.LocalDate.now()).plusDays(1).atStartOfDay();
                     return trendItemRepository.findByAnalysisStatusAndCrawledAtBetweenAndScoreTotalIsNull(
                         TrendItem.AnalysisStatus.DONE, fromDt, toDt)
+                        .stream().map(TrendItem::getId).toList();
+                }
+                if (force) {
+                    return trendItemRepository.findByAnalysisStatusOrderByCrawledAtAsc(TrendItem.AnalysisStatus.DONE)
                         .stream().map(TrendItem::getId).toList();
                 }
                 return trendItemRepository.findByAnalysisStatusAndScoreTotalIsNullOrderByCrawledAtAsc(TrendItem.AnalysisStatus.DONE)

--- a/mud-backend/src/test/java/com/mud/service/AnalysisServiceScoringTest.java
+++ b/mud-backend/src/test/java/com/mud/service/AnalysisServiceScoringTest.java
@@ -240,7 +240,7 @@ class AnalysisServiceScoringTest {
         when(trendItemRepository.findByAnalysisStatusAndScoreTotalIsNullOrderByCrawledAtAsc(any()))
             .thenReturn(List.of());
 
-        service.rescoreExistingItems(null, null);
+        service.rescoreExistingItems(null, null, false);
 
         Map<String, Object> status = service.getRescoreStatus();
         assertThat(status.get("total")).isEqualTo(0);


### PR DESCRIPTION
## Summary
- `force=true` 파라미터 추가: 이미 score_total이 있는 아이템도 강제 재채점
- B32 프롬프트 변경 후 기존 아이템 재채점 용도

## 사용법
```bash
# 오늘분 강제 재채점 (새 프롬프트 적용)
curl -X POST -H "X-API-Key: ..." ".../api/admin/rescore?from=2026-03-30&force=true"

# 기존 동작 (score_total IS NULL만)
curl -X POST -H "X-API-Key: ..." ".../api/admin/rescore?from=2026-03-30"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
