### PR TITLE
fix: IEEE Spectrum RSS URL 수정

### DIFF
--- a/mud-backend/src/main/java/com/mud/crawler/IEEESpectrumCrawler.java
+++ b/mud-backend/src/main/java/com/mud/crawler/IEEESpectrumCrawler.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Slf4j
 public class IEEESpectrumCrawler extends CrawlerBase {
 
-    private static final String RSS_URL = "https://spectrum.ieee.org/feed/";
+    private static final String RSS_URL = "https://spectrum.ieee.org/feeds/feed.rss";
 
     public IEEESpectrumCrawler(TrendItemRepository trendItemRepository) {
         super(trendItemRepository);


### PR DESCRIPTION
## Summary
Related: #200

IEEE Spectrum 크롤러의 RSS URL이 잘못되어 크롤링이 실패하고 있었습니다.

- **기존**: `https://spectrum.ieee.org/feed/` → HTML 페이지 반환 (RSS 아님)
- **수정**: `https://spectrum.ieee.org/feeds/feed.rss` → 정상 RSS 피드

## 확인
- The Next Platform: 50건 정상 크롤링 중
- HPCwire: 10건 정상 크롤링 중
- IEEE Spectrum: 0건 → 이 수정 후 크롤링 시작 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
